### PR TITLE
Start/stop on 'specific date' and time refresh delta

### DIFF
--- a/advanced-timer.lua
+++ b/advanced-timer.lua
@@ -246,7 +246,10 @@ function on_pause(pressed)
 		reset(true)
 	end
 
-	if mode == "Streaming timer" or mode == "Recording timer" then
+	if mode == "Specific date and time" or mode == "Specific time" then
+		total_seconds = delta_time()
+		total = total_seconds
+	elseif mode == "Streaming timer" or mode == "Recording timer" then
 		return
 	end
 


### PR DESCRIPTION
There was an issue where if you clicked the start/stop button when counting down from a specific date and time or specific time where the timer countdown would no longer be at the specific date and time when the timer resumed.  I fixed it by recalculating the delta when unpaused.